### PR TITLE
Prevent errors about python3 not found

### DIFF
--- a/workspace-image/Containerfile
+++ b/workspace-image/Containerfile
@@ -36,6 +36,7 @@ RUN microdnf --disableplugin=subscription-manager install -y ${INSTALL_PACKAGES}
     echo "user:1001:64535" >> /etc/subgid ; \
     setcap cap_setuid+ep /usr/bin/newuidmap ; \
     setcap cap_setgid+ep /usr/bin/newgidmap ; \
+    ln -sf /usr/bin/python3.11 /usr/bin/python3 ; \
     echo "user ALL=NOPASSWD: /set-cgroups.sh" >> /etc/sudoers
 
 USER 1000


### PR DESCRIPTION
The ansible extension in VS Code needs a python3 binary at /usr/bin/python3, otherwise it'll complain at startup. Can no-doubt be fixed by something in the configuration files by the user at start up, but this is nicer because no errors show at all ;)